### PR TITLE
Usando o autoload clássico

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,7 @@ module BankAccounting
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.autoloader = :classic
 
     # Settings in config/environments/* take precedence over those specified
     # here. Application configuration can go into files in config/initializers


### PR DESCRIPTION
1. Alterando para o autoload clássico ([cenário do mónolito](https://github.com/dleemoo/bank-accounting/pull/2/files))

Resultado no console:

```
console 
Starting bank-accounting_pgdb12_1 ... done
Loading development environment (Rails 6.0.0)
[1] pry(main)> FirstLevel::SomeItem.call
NameError: uninitialized constant OtherItem
from /gems/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/active_support.rb:79:in `block in load_missing_constant'
Caused by NameError: uninitialized constant OtherItem
from /gems/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/active_support.rb:60:in `block in load_missing_constant'
```