### PR TITLE
Autoload clássico e referência explícita

### DIFF
--- a/app/services/first_level/some_item.rb
+++ b/app/services/first_level/some_item.rb
@@ -2,7 +2,7 @@ module FirstLevel
   module SomeItem
     class << self
       def call
-        OtherItem
+        self::OtherItem
       end
     end
   end


### PR DESCRIPTION
1. Usando referência ([explícita](https://github.com/dleemoo/bank-accounting/pull/3/files))

- Isso poderia ser aplicado no monólito. Testei na parte em que estava trabalhando hoje.
O problema é que temos muitas construções deste tipo.

Resultado no console:

```
console
Starting bank-accounting_pgdb12_1 ... done
Loading development environment (Rails 6.0.0)
[1] pry(main)> FirstLevel::SomeItem.call
=> FirstLevel::OtherItem
```