### PR TITLE
Update project to use u-case gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem "pg", "1.4.3"
 # managed and versioned database views
 gem "scenic", "1.6.0"
 
+# u-case
+gem "u-case", "4.5.1"
+
 # monads to implement railway oriented programming
 gem "dry-monads", "1.4.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     json (2.6.2)
+    kind (5.10.0)
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -232,6 +233,11 @@ GEM
     timeout (0.3.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
+    u-attributes (2.8.0)
+      kind (>= 4.0, < 6.0)
+    u-case (4.5.1)
+      kind (>= 5.6, < 6.0)
+      u-attributes (>= 2.7, < 3.0)
     unicode-display_width (2.2.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -258,6 +264,7 @@ DEPENDENCIES
   rubocop (= 1.35.1)
   scenic (= 1.6.0)
   simplecov (= 0.21.2)
+  u-case (= 4.5.1)
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/controllers/accounts/create_controller.rb
+++ b/app/controllers/accounts/create_controller.rb
@@ -3,9 +3,15 @@
 module Accounts
   class CreateController < ApplicationController
     def call
-      AccountFactory.call(request_params!)
-        .fmap { |r| respond(r, :created) }
-        .or   { |r| respond(r.errors.to_h, :unprocessable_entity) }
+      Account::Create.call(input)
+        .on_success { |r| respond(r.data[:account], :created) }
+        .on_failure { |r| respond(r.data, :unprocessable_entity) }
+    end
+
+    private
+
+    def input
+      params.permit(:name).to_h
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,15 +11,6 @@ class ApplicationController < ActionController::API
     render json: data, status: status
   end
 
-  # This method is a syntax sugar to skip the repetition of permit all
-  # parameters from params.
-  #
-  # Whenever this method is called, the caller must assume the responsibility
-  # of using parameters in a safe way.
-  def request_params!
-    params.permit!.to_h
-  end
-
   def authenticate
     authenticate_or_request_with_http_token do |token, _options|
       ActiveSupport::SecurityUtils.secure_compare(

--- a/app/controllers/operations/balance_controller.rb
+++ b/app/controllers/operations/balance_controller.rb
@@ -3,9 +3,15 @@
 module Operations
   class BalanceController < ApplicationController
     def call
-      BalanceService.call(request_params!)
-        .fmap { |r| respond(amount: r) }
-        .or   { |r| respond(r.errors.to_h, :unprocessable_entity) }
+      Account::CurrentBalance.call(input)
+        .on_success { |r| respond(r.data) }
+        .on_failure { |r| respond(r.data, :unprocessable_entity) }
+    end
+
+    private
+
+    def input
+      params.permit(:account_id).to_h
     end
   end
 end

--- a/app/controllers/operations/deposit_controller.rb
+++ b/app/controllers/operations/deposit_controller.rb
@@ -3,9 +3,15 @@
 module Operations
   class DepositController < ApplicationController
     def call
-      DepositService.call(request_params!)
-        .fmap { |r| respond(r) }
-        .or   { |r| respond(r.errors.to_h, :unprocessable_entity) }
+      Account::DepositNewAmount.call(input)
+        .on_success { |r| respond(r.data) }
+        .on_failure { |r| respond(r.data, :unprocessable_entity) }
+    end
+
+    private
+
+    def input
+      params.permit(:account_id, :amount).to_h
     end
   end
 end

--- a/app/controllers/operations/transfer_controller.rb
+++ b/app/controllers/operations/transfer_controller.rb
@@ -3,9 +3,15 @@
 module Operations
   class TransferController < ApplicationController
     def call
-      TransferService.call(request_params!)
-        .fmap { |r| respond(r) }
-        .or   { |r| respond(r.errors.to_h, :unprocessable_entity) }
+      Account::TransferAmountToAnotherAccount.call(input)
+        .on_success { |r| respond(r.data) }
+        .on_failure { |r| respond(r.data, :unprocessable_entity) }
+    end
+
+    private
+
+    def input
+      params.permit(:source_account_id, :target_account_id, :amount).to_h
     end
   end
 end

--- a/app/models/account/create.rb
+++ b/app/models/account/create.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Account
+  class Create < Micro::Case
+    attributes :name
+
+    def call!
+      return Failure(result: { name: ["is missing"] }) if name.blank?
+
+      result = AccountFactory.call(name: name)
+
+      return Success(result: { account: result.value! }) if result.success?
+
+      Failure(result: result.failure.errors)
+    end
+  end
+end

--- a/app/models/account/current_balance.rb
+++ b/app/models/account/current_balance.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Account
+  class CurrentBalance < Micro::Case
+    attributes :account_id
+
+    def call!
+      return Failure(result: { account_id: ["is missing"] }) if account_id.blank?
+
+      result = BalanceService.call(account_id: account_id)
+
+      return Success(result: { amount: result.value! }) if result.success?
+
+      Failure(result: result.failure.errors.to_h)
+    end
+  end
+end

--- a/app/models/account/deposit_new_amount.rb
+++ b/app/models/account/deposit_new_amount.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Account
+  class DepositNewAmount < Micro::Case
+    attributes :account_id, :amount
+
+    def call!
+      return Failure(result: input_errors) if input_errors.present?
+
+      result = DepositService.call(account_id: account_id, amount: amount)
+
+      return Success(result: result.value!.attributes) if result.success?
+
+      Failure(result: result.failure.errors.to_h)
+    end
+
+    private
+
+    def input_errors
+      @input_errors ||= { account_id: account_id, amount: amount }.map do |key, value|
+        [key, ["is missing"]] if value.blank?
+      end.select(&:present?).to_h
+    end
+  end
+end

--- a/app/models/account/transfer_amount_to_another_account.rb
+++ b/app/models/account/transfer_amount_to_another_account.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Account
+  class TransferAmountToAnotherAccount < Micro::Case
+    attributes :source_account_id, :target_account_id, :amount
+
+    def call!
+      return Failure(result: input_errors) if input_errors.present?
+
+      result = TransferService.call(input)
+
+      return Success(result: result.value!.attributes) if result.success?
+
+      Failure(result: result.failure.errors.to_h)
+    end
+
+    private
+
+    def input_errors
+      @input_errors ||= input.map do |key, value|
+        [key, ["is missing"]] if value.blank?
+      end.select(&:present?).to_h
+    end
+
+    def input
+      { source_account_id:, target_account_id:, amount: }
+    end
+  end
+end

--- a/spec/controllers/accounts/create_controller_spec.rb
+++ b/spec/controllers/accounts/create_controller_spec.rb
@@ -26,5 +26,16 @@ RSpec.describe Accounts::CreateController, type: :controller do
         expect(response.body).to eq(JSON(name: ["is missing"]))
       end
     end
+
+    context "when account already exists" do
+      it "returns http failure with service message" do
+        Account.create!(name: "acc")
+
+        post :call, params: { name: "acc" }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to eq(JSON(name: ["already taken"]))
+      end
+    end
   end
 end

--- a/spec/controllers/operations/balance_controller_spec.rb
+++ b/spec/controllers/operations/balance_controller_spec.rb
@@ -28,5 +28,14 @@ RSpec.describe Operations::BalanceController, type: :controller do
         expect(response.body).to eq(JSON(account_id: ["is missing"]))
       end
     end
+
+    context "when the account does not exist" do
+      it "returns http failure with service message" do
+        post :call, params: { account_id: "5367aaf6-416b-477f-81d6-2cbe02f6f7eb" }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to eq(JSON(account_id: ["not found"]))
+      end
+    end
   end
 end

--- a/spec/controllers/operations/deposit_controller_spec.rb
+++ b/spec/controllers/operations/deposit_controller_spec.rb
@@ -28,5 +28,14 @@ RSpec.describe Operations::DepositController, type: :controller do
         expect(response.body).to eq(JSON(account_id: ["is missing"], amount: ["is missing"]))
       end
     end
+
+    context "when account does not exist" do
+      it "returns http failure with service message" do
+        post :call, params: { account_id: "5367aaf6-416b-477f-81d6-2cbe02f6f7eb", amount: 20 }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to eq(JSON(account_id: ["not found"]))
+      end
+    end
   end
 end

--- a/spec/controllers/operations/transfer_controller_spec.rb
+++ b/spec/controllers/operations/transfer_controller_spec.rb
@@ -32,5 +32,15 @@ RSpec.describe Operations::TransferController, type: :controller do
         expect(response.body).to eq(JSON(source_account_id: ["insufficient funds"]))
       end
     end
+
+    context "when input is not valid" do
+      it "returns http failure with service message" do
+        deposit.call(acocunt_id: account.id, amount: 100)
+        post :call, params: { source_account_id: account.id, target_account_id: nil, amount: 150 }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to eq(JSON(target_account_id: ["is missing"]))
+      end
+    end
   end
 end


### PR DESCRIPTION
Esse PR adiciona a gem `u-case` e cria a estrutura para os use cases.

O objetivo é organizar como ficariam os use cases em relação a hierarquia de namespaces e nomes dos mesmos.
Além disso, mover a implementação de forma simples, para os use cases permitindo que controllers fosse ajustados.

A opção foi usar os services dentro dos use cases para evitar uma modificação grande e ajustar como os controllers trabalhavam com os dados. Os nomes dos controllers foram mantidos pois não é o foco nesse momento.

Em relação a estrutura, todos os use case ficaram sobre o chapéu da conta. Basicamente pelo fato das operações estarem muito atreladas as contas de fato. Talvez a operação de transferência deveria ficar em outro namespace, ou até mesmo manter a estrutura do controle e todas as operações não seriam de account. Mas pareceu fazer sentido pensar nas operações como algo que uma conta tem de use case.

Todas as modificações estão em um único commit (c0e85e768efce9f3e9608f94ddd84af78e45461c).

## Notas para o refactory

Esse PR mantém os use case sem testes. Eles são nesse momento, wrappers para os antigos services.
Para garantir que todo o código dos use casess eram executados testes extras foram adicionados no controller.

O objetivo é ter um comparativo fácil de como os testes mudaram dos antigos services para os use cases.

Com o controller exercitando as novas partes dos use cases, há pouco problema adicionado para o refactory.